### PR TITLE
Save changes put request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2513,6 +2513,27 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "method-override": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
+      "integrity": "sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==",
+      "requires": {
+        "debug": "3.1.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^2.0.0",
     "ejs": "^2.6.2",
     "express": "^4.17.1",
+    "method-override": "^3.0.0",
     "morgan": "^1.9.1",
     "node-sass-middleware": "^0.11.0",
     "pg": "^6.4.2",

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -7,12 +7,13 @@ $(() => {
       $("<div>").text(user.name).appendTo($("body"));
     }
   });
-
-
 });
 
 // Copy to clipboard function for modal
-$(".copy").on("click", function() {
+$(".copy").on("click", function (event) {
+  // Stop the copy button from submitting a PUT request
+  event.preventDefault();
+
   // Remove disable to allow copy function
   const $passwordBox = $(".copy").parents().siblings(".passwordBox");
   $passwordBox.prop("disabled", false);

--- a/routes/helpers/db_helpers.js
+++ b/routes/helpers/db_helpers.js
@@ -274,7 +274,7 @@ module.exports = (db) => {
    * @param {{id: Number, website_title: String, website_url: String, website_username: String, website_pwd: String, category: String}} new_pwd The new pwd object
    * @return {Promise<{}>} A promise to query the db
    */
-  const modifyPwd = function (new_pwd) {
+  const modifyPwd = function (newPwd) {
     const queryParams = [];
 
     let queryString = `
@@ -283,28 +283,28 @@ module.exports = (db) => {
     `;
 
     // Check which fields were passed in and need to be updated
-    if (new_pwd.website_title) {
-      queryParams.push(new_pwd.website_title);
+    if (newPwd.website_title) {
+      queryParams.push(newPwd.website_title);
       queryString += `website_title=$${queryParams.length}, `;
     }
 
-    if (new_pwd.website_url) {
-      queryParams.push(new_pwd.website_url);
+    if (newPwd.website_url) {
+      queryParams.push(newPwd.website_url);
       queryString += `website_url=$${queryParams.length}, `;
     }
 
-    if (new_pwd.website_username) {
-      queryParams.push(new_pwd.website_username);
+    if (newPwd.website_username) {
+      queryParams.push(newPwd.website_username);
       queryString += `website_username=$${queryParams.length}, `;
     }
 
-    if (new_pwd.website_pwd) {
-      queryParams.push(new_pwd.website_pwd);
+    if (newPwd.website_pwd) {
+      queryParams.push(newPwd.website_pwd);
       queryString += `website_pwd=$${queryParams.length}, `;
     }
 
-    if (new_pwd.category) {
-      queryParams.push(new_pwd.category);
+    if (newPwd.category) {
+      queryParams.push(newPwd.category);
       queryString += `category=$${queryParams.length}, `;
     }
 
@@ -312,7 +312,7 @@ module.exports = (db) => {
     queryString = queryString.slice(0, -2);
 
     // WHERE clause
-    queryParams.push(new_pwd.id);
+    queryParams.push(newPwd.id);
     queryString += `
     WHERE id=$${queryParams.length}
     RETURNING *;`;

--- a/routes/helpers/db_helpers.js
+++ b/routes/helpers/db_helpers.js
@@ -279,34 +279,37 @@ module.exports = (db) => {
 
     let queryString = `
     UPDATE pwd
-    SET 
+    SET
     `;
 
     // Check which fields were passed in and need to be updated
     if (new_pwd.website_title) {
-      queryParams.push(website_title);
+      queryParams.push(new_pwd.website_title);
       queryString += `website_title=$${queryParams.length}, `;
     }
 
     if (new_pwd.website_url) {
-      queryParams.push(website_url);
+      queryParams.push(new_pwd.website_url);
       queryString += `website_url=$${queryParams.length}, `;
     }
 
     if (new_pwd.website_username) {
-      queryParams.push(website_username);
+      queryParams.push(new_pwd.website_username);
       queryString += `website_username=$${queryParams.length}, `;
     }
 
     if (new_pwd.website_pwd) {
-      queryParams.push(website_pwd);
+      queryParams.push(new_pwd.website_pwd);
       queryString += `website_pwd=$${queryParams.length}, `;
     }
 
     if (new_pwd.category) {
-      queryParams.push(category);
+      queryParams.push(new_pwd.category);
       queryString += `category=$${queryParams.length}, `;
     }
+
+    // Remove last comma
+    queryString = queryString.slice(0, -2);
 
     // WHERE clause
     queryParams.push(new_pwd.id);

--- a/routes/helpers/db_helpers.js
+++ b/routes/helpers/db_helpers.js
@@ -269,6 +269,61 @@ module.exports = (db) => {
       .catch((e) => console.log(e));
   };
 
+  /**
+   * Modify a password from the db given a new new_pwd object
+   * @param {{id: Number, website_title: String, website_url: String, website_username: String, website_pwd: String, category: String}} new_pwd The new pwd object
+   * @return {Promise<{}>} A promise to query the db
+   */
+  const modifyPwd = function (new_pwd) {
+    const queryParams = [];
+
+    let queryString = `
+    UPDATE pwd
+    SET 
+    `;
+
+    // Check which fields were passed in and need to be updated
+    if (new_pwd.website_title) {
+      queryParams.push(website_title);
+      queryString += `website_title=$${queryParams.length}, `;
+    }
+
+    if (new_pwd.website_url) {
+      queryParams.push(website_url);
+      queryString += `website_url=$${queryParams.length}, `;
+    }
+
+    if (new_pwd.website_username) {
+      queryParams.push(website_username);
+      queryString += `website_username=$${queryParams.length}, `;
+    }
+
+    if (new_pwd.website_pwd) {
+      queryParams.push(website_pwd);
+      queryString += `website_pwd=$${queryParams.length}, `;
+    }
+
+    if (new_pwd.category) {
+      queryParams.push(category);
+      queryString += `category=$${queryParams.length}, `;
+    }
+
+    // WHERE clause
+    queryParams.push(new_pwd.id);
+    queryString += `
+    WHERE id=$${queryParams.length}
+    RETURNING *;`;
+
+    return db
+      .query(queryString, queryParams)
+      .then((res) => {
+        return res.rows[0];
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
   return {
     getUserWithEmail,
     login,
@@ -282,5 +337,6 @@ module.exports = (db) => {
     doesOrgExist,
     isUserAdmin,
     addPwdToOrg,
+    modifyPwd,
   };
 };

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -4,6 +4,32 @@ const router = express.Router();
 module.exports = (db) => {
   const dbHelpers = require("./helpers/db_helpers")(db);
 
+  router.put("/:org_id/:pwd_id", (req, res) => {
+    const { org_id, pwd_id } = req.params;
+    dbHelpers.isUserAdmin(org_id, req.session.userId).then((admin) => {
+      if (!admin) {
+        return res
+          .status(403)
+          .send("You are not authorized to change the password!");
+      }
+
+      // Create a newPwd object from the form values passed in
+      const newPwd = req.body;
+
+      // Delete keys that were not passed in through the form
+      for (const key of Object.keys(newPwd)) {
+        if (!newPwd[key]) {
+          delete newPwd[key];
+        }
+      }
+
+      dbHelpers
+        .modifyPwd(newPwd)
+        .then(res.redirect(`orgs/${org_id}`))
+        .catch((e) => res.send(e));
+    });
+  });
+
   router.get("/new", (req, res) => {
     dbHelpers
       .getUserWithId(req.session.userId) // Get user id
@@ -24,8 +50,7 @@ module.exports = (db) => {
   router.post("/new", (req, res) => {
     const org = req.body;
     dbHelpers.getUserWithId(req.session.userId).then((user) => {
-      dbHelpers.addOrg(org, user).then((data) => {
-        console.log(data);
+      dbHelpers.addOrg(org, user).then((data) => {        
         return res.redirect(`/orgs/${data.org_id}`);
       });
     });
@@ -89,31 +114,6 @@ module.exports = (db) => {
       }
     });
 
-    router.put(":org_id/:pwd_id", (req, res) => {
-      const { org_id, pwd_id } = req.params;
-      dbHelpers.isUserAdmin(org_id, req.session.userId).then((admin) => {
-        if (!admin) {
-          return res
-            .status(403)
-            .send("You are not authorized to change the password!");
-        }
-
-        // Create a newPwd object from the form values passed in
-        const newPwd = req.body;
-
-        // Delete keys that were not passed in through the form
-        for (const key of Object.keys(newPwd)) {
-          if (!newPwd[key]) {
-            delete newPwd[key];
-          }
-        }
-
-        dbHelpers
-          .modifyPwd(newPwd)
-          .then(res.redirect("orgs/${org_id"))
-          .catch((e) => res.send(e));
-      });
-    });
     //   dbHelpers
     //     .getUserWithId(req.session.userId)
     //     .then((user) => {

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -89,6 +89,9 @@ module.exports = (db) => {
       }
     });
 
+    router.put(":org_id/:pwd_id", (req, res) => {
+      const { org_id, pwd_id } = req.body.params;
+    });
     //   dbHelpers
     //     .getUserWithId(req.session.userId)
     //     .then((user) => {

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -15,6 +15,7 @@ module.exports = (db) => {
 
       // Create a newPwd object from the form values passed in
       const newPwd = req.body;
+      newPwd.id = pwd_id;
 
       // Delete keys that were not passed in through the form
       for (const key of Object.keys(newPwd)) {
@@ -50,7 +51,7 @@ module.exports = (db) => {
   router.post("/new", (req, res) => {
     const org = req.body;
     dbHelpers.getUserWithId(req.session.userId).then((user) => {
-      dbHelpers.addOrg(org, user).then((data) => {        
+      dbHelpers.addOrg(org, user).then((data) => {
         return res.redirect(`/orgs/${data.org_id}`);
       });
     });

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -90,7 +90,29 @@ module.exports = (db) => {
     });
 
     router.put(":org_id/:pwd_id", (req, res) => {
-      const { org_id, pwd_id } = req.body.params;
+      const { org_id, pwd_id } = req.params;
+      dbHelpers.isUserAdmin(org_id, req.session.userId).then((admin) => {
+        if (!admin) {
+          return res
+            .status(403)
+            .send("You are not authorized to change the password!");
+        }
+
+        // Create a newPwd object from the form values passed in
+        const newPwd = req.body;
+
+        // Delete keys that were not passed in through the form
+        for (const key of Object.keys(newPwd)) {
+          if (!newPwd[key]) {
+            delete newPwd[key];
+          }
+        }
+
+        dbHelpers
+          .modifyPwd(newPwd)
+          .then(res.redirect("orgs/${org_id"))
+          .catch((e) => res.send(e));
+      });
     });
     //   dbHelpers
     //     .getUserWithId(req.session.userId)

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const sass = require("node-sass-middleware");
 const app = express();
 const morgan = require("morgan");
 const cookieSession = require("cookie-session");
+const methodOverride = require('method-override')
 
 // PG database client/connection setup
 const { Pool } = require("pg");
@@ -39,6 +40,7 @@ app.use(
     keys: ["key1"],
   })
 );
+app.use(methodOverride('_method'));
 app.use(express.static("public"));
 
 // Separated Routes for each Resource

--- a/views/organization.ejs
+++ b/views/organization.ejs
@@ -53,7 +53,7 @@
       aria-hidden="true"
     >
       <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
+        <form class="modal-content" action='/orgs/<%=pwd.org_id%>/<%=pwd.id%>?_method=PUT' method='POST'>
           <div class="modal-header">
             <h5 class="modal-title" id="title"><%=pwd.website_title%></h5>
           </div>
@@ -69,6 +69,7 @@
               class="passwordBox"
               type="text"
               value="<%= pwd.website_pwd%>"
+              name="website_pwd"
             />
             <% if(isUserAdminTrueOrNot) { %>
             <div><button class="change">Change Password</button></div>
@@ -85,7 +86,7 @@
             </button>
             <button type="button" class="btn btn-primary">Save changes</button>
           </div>
-        </div>
+        </form>
       </div>
     </div>
     <% }); } %>


### PR DESCRIPTION
- The "show passwords" modal is now classified as a form, so all buttons that aren't "save changes" or "close" need to include `event.stopPropagation`
- The password box was already an `<input>` so I added `name=website_pwd` so it is passed in as `req.body.website_pwd`.
- The `router.put` can take in all the params in the forms... right now only `website_pwd` is passed in. If you add more fields to change, make sure the `<input name=`  is same as database column name
- I could only test with curl since the "change password" button isn't implemented yet
- modifyPwd(newPwd) is capable of taking any number of fields inside newPwd object, only newPwd.id is required
